### PR TITLE
Bug fix for max_pooling_2d

### DIFF
--- a/manim_ml/neural_network/layers/convolutional_2d_to_max_pooling_2d.py
+++ b/manim_ml/neural_network/layers/convolutional_2d_to_max_pooling_2d.py
@@ -174,7 +174,6 @@ class Convolutional2DToMaxPooling2D(ConnectiveLayer, ThreeDLayer):
                 gridded_rectangle,
                 output_gridded_rectangle,
                 introducer=True,
-                remover=True,
             )
             transform_gridded_rectangle_animations.append(
                 transform_rectangle,


### PR DESCRIPTION
Removed `remover` argument from `ReplacementTrasform` which resulted in "Could not find old_mobject in Scene" error when cleaning up the scene.